### PR TITLE
Sets db check on load_segments to datestop instead of datestart.

### DIFF
--- a/skawatch.py
+++ b/skawatch.py
@@ -129,7 +129,7 @@ jws.extend([
     SkaDbWatch('aiprops', 4),
     SkaDbWatch('cmds', -1, timekey='date'),
     SkaDbWatch('cmd_states', -1, timekey='datestart'),
-    SkaDbWatch('load_segments', -1, timekey='datestart'),
+    SkaDbWatch('load_segments', -1, timekey='datestop'),
     SkaDbWatch('obspar', 4),
     SkaDbWatch('starcheck_obs', 4, timekey='mp_starcat_time'),
     SkaDbWatch('trak_stats_data', 4, timekey='kalman_tstart'),


### PR DESCRIPTION
It is not uncommon to have a 4 day load segment at the end of the week
and to not approve loads until 3 days before the end of the week.
Checking that datestart of the last load segment is at least 1 day in
the future is prone to false positives.  Checking datestop should be
more reliable and informative for this data type.
