### PR TITLE
Fix false warnings due to eng archive MSIDs with FAIL substring

### DIFF
--- a/skawatch.py
+++ b/skawatch.py
@@ -76,7 +76,7 @@ astromon_errs = ('uninitialized value', 'warn', 'fatal', 'fail',
                  'ERROR(?!: Data::ParseTable: FITS ' +
                  'files cannot be passed as arrays)')
 engarchive_errs = copy_errs(py_errs, ['fail'],
-                             ['(?<!5OHW)FAIL'])
+                             ['(?<!5OHW)FAIL(?!MODE)'])
 perigee_errs = copy_errs(py_errs, ['warn'],
                          ['warning(?!: Limit Exceeded. dac of)'])
 jean_db = '/proj/sot/ska/data/database/Logs/daily.0/{task}.log'


### PR DESCRIPTION
Line 35916: 2012-12-13 07:12:06,709 Appending 840 items to /proj/sot/ska/data/eng_archive/data/ephhk/SCFAILMODEGC.h5
