### PR TITLE
Check that the last kadi dwell < 3 days old

### DIFF
--- a/jobwatch/skawatch.py
+++ b/jobwatch/skawatch.py
@@ -62,7 +62,7 @@ class SkaJobWatch(JobWatch):
 class KadiWatch(JobWatch):
     def __init__(self, task, filename, maxage=1):
         self.type = 'Application Data'
-        super(KadiWatch, self).__init__(task, filename, maxage=maxage)
+        super().__init__(task, filename, maxage=maxage)
 
     @property
     def filelines(self):
@@ -71,11 +71,10 @@ class KadiWatch(JobWatch):
     @property
     def age(self):
         if not hasattr(self, '_age'):
-            dwells = events.dwells.filter(-20)
-            last_dwell = dwells[len(dwells) - 1]
-            self.filetime = CxoTime(last_dwell.start).unix
+            last_dwell = events.dwells.all().last()
+            self.filetime = CxoTime(last_dwell.stop).unix
             self.filedate = time.ctime(self.filetime)
-            self._age = (CxoTime().now() - CxoTime(last_dwell.start)).to_value(u.day)
+            self._age = (CxoTime.now() - CxoTime(last_dwell.stop)).to_value(u.day)
         return self._age
 
 

--- a/jobwatch/skawatch.py
+++ b/jobwatch/skawatch.py
@@ -1,8 +1,14 @@
 #!/usr/bin/env python
 
 import argparse
-import jobwatch
 from glob import glob
+import astropy.units as u
+import time
+
+from cxotime import CxoTime
+from kadi import events
+
+import jobwatch
 from jobwatch import (FileWatch, JobWatch, DbWatch,
                       make_html_report, copy_errs,
                       set_report_attrs)
@@ -51,6 +57,26 @@ class SkaJobWatch(JobWatch):
                                           requires=requires,
                                           exclude_errors=exclude_errors,
                                           maxage=maxage)
+
+
+class KadiWatch(JobWatch):
+    def __init__(self, task, filename, maxage=1):
+        self.type = 'Application Data'
+        super(KadiWatch, self).__init__(task, filename, maxage=maxage)
+
+    @property
+    def filelines(self):
+        return []
+
+    @property
+    def age(self):
+        if not hasattr(self, '_age'):
+            dwells = events.dwells.filter(-20)
+            last_dwell = dwells[len(dwells) - 1]
+            self.filetime = CxoTime(last_dwell.start).unix
+            self.filedate = time.ctime(self.filetime)
+            self._age = (CxoTime().now() - CxoTime(last_dwell.start)).to_value(u.day)
+        return self._age
 
 
 class SkaDbWatch(DbWatch):
@@ -224,6 +250,8 @@ def main():
         SkaSqliteDbWatch('timeline_loads', -1, timekey='datestop',
                          dbfile='/proj/sot/ska/data/cmd_states/cmd_states.db3'),
     ])
+
+    jws.extend([KadiWatch('kadi dwells', '/proj/sot/ska/data/kadi/events3.db3', maxage=3)])
 
     set_report_attrs(jws)
     index_html = make_html_report(jws, args.rootdir, args.date_now)


### PR DESCRIPTION
Check that the last kadi dwell < 3 days old

For testing, I ran this as `jobwatch.skawatch.main()` and reviewed the output HTML.  It seems reasonable:

<img width="569" alt="Screen Shot 2021-06-25 at 10 59 11 AM" src="https://user-images.githubusercontent.com/791508/123444462-e8adf700-d5a4-11eb-800f-1c23ab1c90b3.png">

Independent inspection of kadi dwells shows the last stop time about 0.62 days from "now".  I didn't confirm the time in local but seems reasonable.

When I ran this code weeks ago when kadi was stuck, I saw the "red" that I expected in the report (code has changed a bit since then, but same idea).