### PR TITLE
Use new solar wind png instead of old gif

### DIFF
--- a/jobwatch/skawatch.py
+++ b/jobwatch/skawatch.py
@@ -198,7 +198,7 @@ def main():
         SkaWebWatch('arc', 1, 'timeline.png'),
         SkaWebWatch('arc', 1, 'hrc_shield.png'),
         SkaWebWatch('arc', 2, 'GOES_5min.gif'),
-        SkaWebWatch('arc', 24, 'solar_wind.gif'),
+        SkaWebWatch('arc', 24, 'solar_wind.png'),
         SkaWebWatch('arc', 24, 'solar_flare_monitor.png'),
         SkaWebWatch('arc', 2, 'ACE_5min.gif'),
         SkaWebWatch('celmon', 30, 'offsets-ACIS-S-hist.gif'),


### PR DESCRIPTION
## Description

Update jobwatch to pay attention to the new file name for the solar wind data.

## Interface impacts
No impact.
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing

### Unit tests
- [x] Linux

### Functional tests
For functional tests, I confirmed the solar wind warning goes away with the new code using the new timestamp on the new file.
