### PR TITLE
Re-enable astromon checks

### DIFF
--- a/jobwatch/skawatch.py
+++ b/jobwatch/skawatch.py
@@ -111,6 +111,7 @@ telem_archive_errs = copy_errs(py_errs, ['fail'],
                                ['(?<!...)fail(?!...)'])
 perigee_errs = copy_errs(py_errs, ['warn'],
                          ['warn(?!ing: limit exceeded, dac of)'])
+astromon_errs = ('error', 'fatal', 'fail')
 engarchive_errs = copy_errs(py_errs, ['fail'],
                             ['(?<!5OHW)FAIL(?!MODE)'])
 perigee_errs = copy_errs(py_errs, ['warn'],
@@ -136,6 +137,7 @@ def main():
         SkaJobWatch('aimpoint_mon', 2, errors=py_errs),
         SkaJobWatch('arc', 2, errors=perl_errs,
                     exclude_errors=arc_exclude_errors, logdir='Logs'),
+        SkaJobWatch('astromon', 8, errors=astromon_errs),
         SkaJobWatch('attitude_error_mon', 2, errors=att_mon_errs),
         SkaJobWatch('aca_weekly_report', 3, errors=py_errs,
                     filename='/proj/sot/ska/data/aca_weekly_report/logs/aca_weekly_report.log'),

--- a/jobwatch/skawatch.py
+++ b/jobwatch/skawatch.py
@@ -196,7 +196,7 @@ def main():
         SkaWebWatch('arc', 24, 'solar_wind.png'),
         SkaWebWatch('arc', 24, 'solar_flare_monitor.png'),
         SkaWebWatch('arc', 2, 'ACE_5min.gif'),
-        SkaWebWatch('celmon', 30, 'offsets-ACIS-S-hist.gif'),
+        SkaWebWatch('celmon', 30, 'offsets-ACIS-S-history.png'),
         FileWatch(
             'centroid reports', 2,
             filename='/proj/sot/ska/www/ASPECT_ICXC/centroid_reports/guide_metrics_obsid.dat'),


### PR DESCRIPTION
## Description

This enables astromon checks (with different error messages) and changes the image filename to check for the celmon webpage. This is according to the latest astromon python release.

## Interface impacts
None

## Testing
No testing yet. How do we test this with it running to begin with?

### Unit tests


Independent check of unit tests by Jean
- [X] Linux

### Functional tests

No functional testing.
