### PR TITLE
Add kadi validate and remove timelines/cmds_states

### DIFF
--- a/jobwatch/skawatch.py
+++ b/jobwatch/skawatch.py
@@ -149,11 +149,10 @@ def main():
 
         SkaJobWatch('kadi', 1, logtask='kadi_events', errors=py_errs,
                     exclude_errors=['InsecureRequestWarning']),
-
         SkaJobWatch('kadi', 1, logtask='kadi_cmds', errors=py_errs),
+        SkaJobWatch('kadi', 1, logtask='kadi_validate', errors=py_errs),
         SkaJobWatch('star_stats', 2, filename=star_stat,
                     exclude_errors=['Cannot determine guide transition time']),
-        SkaJobWatch('timelines', 2, logtask='timelines_cmd_states', logdir='Logs'),
         SkaJobWatch('mica', 2, errors=trace_plus_errs,
                     filename='/proj/sot/ska/data/mica/logs/daily.0/mica_archive.log',
                     exclude_errors=["Running get_observed_att_errors",
@@ -173,7 +172,6 @@ def main():
         SkaJobWatch('star_database', 2, filename=jean_db),
         SkaJobWatch('starcheck_database', 2, filename=jean_db),
         SkaJobWatch('vv_database', 2, filename=jean_db),
-        SkaJobWatch('validate_states', 2, errors=trace_plus_errs),
         SkaJobWatch('scs107', 2, logdir='Logs', logtask='scs107_check'),
         SkaJobWatch('telem_archive', 2, errors=telem_archive_errs,
                     exclude_errors=['WARNING - no kalman interval for obsid 4']),
@@ -236,10 +234,6 @@ def main():
     jws.extend([
         SkaSqliteDbWatch('starcheck_obs', -1, timekey='mp_starcat_time',
                          dbfile='/proj/sot/ska/data/mica/archive/starcheck/starcheck.db3'),
-        SkaSqliteDbWatch('load_segments', -1, timekey='datestop',
-                         dbfile='/proj/sot/ska/data/cmd_states/cmd_states.db3'),
-        SkaSqliteDbWatch('timeline_loads', -1, timekey='datestop',
-                         dbfile='/proj/sot/ska/data/cmd_states/cmd_states.db3'),
     ])
 
     jws.extend([KadiWatch('kadi dwells', '/proj/sot/ska/data/kadi/events3.db3', maxage=3)])


### PR DESCRIPTION
## Description
Do log checking for updated kadi validate logs.

Remove validate_states and checking of timelines logs.

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes #59

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux

```
ska3-jeanconn-fido> git rev-parse HEAD
b1a18c4cb470f41e1949b10fd408cfd98b266a5d
ska3-jeanconn-fido> pytest
================================================== test session starts ==================================================
platform linux -- Python 3.10.8, pytest-7.2.1, pluggy-1.0.0
rootdir: /proj/sot/ska/jeanproj/git, configfile: pytest.ini
plugins: anyio-3.6.2, timeout-2.1.0
collected 10 items                                                                                                      

jobwatch/tests/test_jobwatch.py ..........                                                                        [100%]

================================================== 10 passed in 2.91s
```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Run today, locally with output out to:

https://icxc.cfa.harvard.edu/aspect/test_review_outputs/jobwatch-pr61/2024022/

validate_states output is gone and the third kadi entry is now for the validation logs.
