### PR TITLE
Remove checks that use Python Sybase

### DIFF
--- a/jobwatch/hourly_watch.py
+++ b/jobwatch/hourly_watch.py
@@ -10,7 +10,7 @@ import requests
 import tables
 from glob import glob
 
-from Chandra.Time import DateTime
+from chandra_time import DateTime
 
 from jobwatch import (FileWatch, JobWatch,
                       make_html_report,

--- a/jobwatch/jobwatch.py
+++ b/jobwatch/jobwatch.py
@@ -10,8 +10,8 @@ from email.mime.text import MIMEText
 import shutil
 
 import jinja2
-import Ska.DBI
-from Chandra.Time import DateTime
+import ska_dbi
+from chandra_time import DateTime
 
 LOUD = False
 ERRORS = ('error', 'warn', 'fail', 'fatal', 'exception', 'traceback')
@@ -144,7 +144,7 @@ class DbWatch(JobWatch):
     @property
     def age(self):
         if not hasattr(self, '_age'):
-            with Ska.DBI.DBI(
+            with ska_dbi.DBI(
                     dbi=self.dbi, server=self.server, user=self.user,
                     database=self.database, passwd=self.passwd) as db:
                 row = db.fetchone(self.query)

--- a/jobwatch/skawatch.py
+++ b/jobwatch/skawatch.py
@@ -215,7 +215,6 @@ def main():
 
     ])
 
-
     jws.extend([
         SkaSqliteDbWatch('starcheck_obs', -1, timekey='mp_starcat_time',
                          dbfile='/proj/sot/ska/data/mica/archive/starcheck/starcheck.db3'),

--- a/jobwatch/skawatch.py
+++ b/jobwatch/skawatch.py
@@ -78,14 +78,6 @@ class KadiWatch(JobWatch):
         return self._age
 
 
-class SkaDbWatch(DbWatch):
-    def __init__(self, task, maxage=1, table=None, timekey='tstart'):
-        super(SkaDbWatch, self).__init__(
-            task, maxage=maxage, table=table, timekey=timekey,
-            query='SELECT MAX({timekey}) AS maxtime FROM {table}',
-            dbi='sybase', server='sybase', user='aca_read', database='aca')
-
-
 class SkaSqliteDbWatch(DbWatch):
     def __init__(self, task, maxage=1, dbfile=None, table=None, timekey='tstart'):
         super(SkaSqliteDbWatch, self).__init__(
@@ -223,13 +215,6 @@ def main():
 
     ])
 
-    jws.extend([
-        SkaDbWatch('acq_stats_data', 4),
-        SkaDbWatch('aiprops', 4),
-        SkaDbWatch('obspar', 4),
-        SkaDbWatch('starcheck_obs', 4, timekey='mp_starcat_time'),
-        SkaDbWatch('trak_stats_data', 4, timekey='kalman_tstart'),
-    ])
 
     jws.extend([
         SkaSqliteDbWatch('starcheck_obs', -1, timekey='mp_starcat_time',

--- a/jobwatch/tests/test_jobwatch.py
+++ b/jobwatch/tests/test_jobwatch.py
@@ -28,14 +28,6 @@ class SkaJobWatch(jobwatch.JobWatch):
                                           maxage=maxage)
 
 
-class SkaDbWatch(jobwatch.DbWatch):
-    def __init__(self, task, maxage=1, table=None, timekey='tstart'):
-        super(SkaDbWatch, self).__init__(
-            task, maxage=maxage, table=table, timekey=timekey,
-            query='SELECT MAX({timekey}) AS maxtime FROM {table}',
-            dbi='sybase', server='sybase', user='aca_read', database='aca')
-
-
 class SkaSqliteDbWatch(jobwatch.DbWatch):
     def __init__(self, task, maxage=1, dbfile=None, table=None, timekey='tstart'):
         super(SkaSqliteDbWatch, self).__init__(
@@ -100,19 +92,6 @@ def test_filewatch(tmpdir):
     jws = [Watch(task='obc_rate_noise', filename=jobfile, maxage=50)]
     jobwatch.set_report_attrs(jws)
     jobwatch.make_html_report(jws, rootdir=os.path.join(tmpdir, 'out_file'))
-
-
-def test_dbwatch(tmpdir):
-    Watch = SkaDbWatch
-    jws = [Watch('DB acq_stats_data', timekey='tstart',
-                 table='acq_stats_data', maxage=4),
-           Watch('DB trak_stats_data', timekey='kalman_tstart',
-                 table='trak_stats_data', maxage=4),
-           Watch('DB obspar', timekey='tstart', table='obspar', maxage=4),
-           Watch('DB aiprops', timekey='tstart', table='aiprops', maxage=4),
-           ]
-    jobwatch.set_report_attrs(jws)
-    jobwatch.make_html_report(jws, rootdir=os.path.join(tmpdir, 'out_db'))
 
 
 def test_make_html_report(tmpdir):


### PR DESCRIPTION
## Description

Remove checks that use Python Sybase

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux

```
(ska3-masters) jeanconn-fido> git rev-parse HEAD
efbfcc43931934a3f584d2ed10b4b660c8cea031
(ska3-masters) jeanconn-fido> pytest
=========================================================================== test session starts ============================================================================
platform linux -- Python 3.10.8, pytest-7.2.1, pluggy-1.0.0
rootdir: /proj/sot/ska/jeanproj/git, configfile: pytest.ini
plugins: timeout-2.1.0, anyio-3.6.2
collected 9 items                                                                                                                                                          

jobwatch/tests/test_jobwatch.py .........                                                                                                                            [100%]

============================================================================ 9 passed in 1.14s
```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Outputs are as-expected with the direct sybase checks removed.

Hourly MTA output https://icxc.cfa.harvard.edu/aspect/test_review_outputs/jobwatch-pr664/hourly_mta/status/
Hourly Ska output https://icxc.cfa.harvard.edu/aspect/test_review_outputs/jobwatch-pr664/hourly_ska/status/
Daily report https://icxc.cfa.harvard.edu/aspect/test_review_outputs/jobwatch-pr664/2024043/
