### PR TITLE
Ignore AstropyDeprecationWarning from arc

### DIFF
--- a/jobwatch/skawatch.py
+++ b/jobwatch/skawatch.py
@@ -114,7 +114,8 @@ perl_errs = set(('uninitialized value',
                  'warn', 'fatal', 'fail', 'undefined value'))
 arc_exclude_errors = [
     r'warning:\s+\d+\s',
-    'file contains 0 lines that start with AVERAGE']
+    'file contains 0 lines that start with AVERAGE',
+    'WARNING: AstropyDeprecationWarning: "Reader" was deprecated']
 nmass_errs = copy_errs(py_errs, ('warn', 'fail'),
                        ('warn(?!ing: imaging routines will not be available)',
                         'fail(?!ed to import sherpa)'))


### PR DESCRIPTION
## Description

Ignore AstropyDeprecationWarning from arc.

The code does need to be fixed in get_ace.py in arc, but that's FSDS code and this change to ignore it can just go in jobwatch now -- removing noise that could keep us from seeing a real issue in the meantime.


## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux

```
(ska3-masters) jeanconn-fido> git rev-parse HEAD
5e693b12b983c920e7896663c1ed74c7f0f119e0
(ska3-masters) jeanconn-fido> pytest
=================================================== test session starts ====================================================
platform linux -- Python 3.11.8, pytest-8.0.2, pluggy-1.4.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: timeout-2.2.0, anyio-4.3.0
collected 9 items                                                                                                          

jobwatch/tests/test_jobwatch.py .........                                                                            [100%]

==================================================== 9 passed in 8.54s
```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
[skawatch_daily output](https://icxc.cfa.harvard.edu/aspect/test_review_outputs/jobwatch/jobwatch-pr68/2024082/)
