### PR TITLE
Turn off an unhelpful replan central warning

### DIFF
--- a/jobwatch/skawatch.py
+++ b/jobwatch/skawatch.py
@@ -115,7 +115,8 @@ perl_errs = set(('uninitialized value',
 arc_exclude_errors = [
     r'warning:\s+\d+\s',
     'file contains 0 lines that start with AVERAGE',
-    'WARNING: AstropyDeprecationWarning: "Reader" was deprecated']
+    'WARNING: AstropyDeprecationWarning: "Reader" was deprecated',
+    "Warning: failed to open URL ftp://ftp.swpc.noaa.gov/pub/lists/ace/ace_epam_5m.txt"]
 nmass_errs = copy_errs(py_errs, ('warn', 'fail'),
                        ('warn(?!ing: imaging routines will not be available)',
                         'fail(?!ed to import sherpa)'))

--- a/jobwatch/skawatch.py
+++ b/jobwatch/skawatch.py
@@ -146,8 +146,6 @@ def main():
 
     jws = []
     jws.extend([
-        SkaJobWatch('aca_hi_bgd_mon', 2, errors=py_errs,
-                    filename='/proj/sot/ska/data/aca_hi_bgd_mon/logs/daily.0/aca_hi_bgd.log'),
         SkaJobWatch('acdc', 2, errors=py_errs),
         SkaJobWatch('aimpoint_mon3', 2, errors=py_errs),
         SkaJobWatch('arc', 2, errors=perl_errs,

--- a/jobwatch/skawatch.py
+++ b/jobwatch/skawatch.py
@@ -146,6 +146,8 @@ def main():
 
     jws = []
     jws.extend([
+        SkaJobWatch('aca_hi_bgd_mon', 2, errors=py_errs,
+                    filename='/proj/sot/ska/data/aca_hi_bgd_mon/logs/daily.0/aca_hi_bgd.log'),
         SkaJobWatch('acdc', 2, errors=py_errs),
         SkaJobWatch('aimpoint_mon3', 2, errors=py_errs),
         SkaJobWatch('arc', 2, errors=perl_errs,


### PR DESCRIPTION
## Description

Turn off an unhelpful replan central warning.


## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux
```
ska3-jeanconn-fido> git rev-parse HEAD
33dbac7bf67a0ab042303c71d2eaa3d27d4f6159
ska3-jeanconn-fido> pytest
====================================================================== test session starts ======================================================================
platform linux -- Python 3.11.8, pytest-7.4.4, pluggy-1.4.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: anyio-4.3.0, timeout-2.2.0
collected 9 items                                                                                                                                               

jobwatch/tests/test_jobwatch.py .........                                                                                                                 [100%]

======================================================================= 9 passed in 2.70s
```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
