### PR TITLE
Update Python warning filter to catch warning not warn

### DIFF
--- a/jobwatch/skawatch.py
+++ b/jobwatch/skawatch.py
@@ -108,7 +108,7 @@ class SkaSqliteDbWatch(DbWatch):
 
 
 # Customized errors and paths
-py_errs = set(('error', 'warn', 'fail', 'fatal', 'exception', 'traceback'))
+py_errs = set(('error', 'warning', 'fail', 'fatal', 'exception', 'traceback'))
 perl_errs = set(('uninitialized value',
                  '(?<!Program caused arithmetic )error',
                  'warn', 'fatal', 'fail', 'undefined value'))


### PR DESCRIPTION
## Description

Update Python warning filter to catch warning not warn

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
This should fix the log checker catching already "mangled" errors like
```
2025-12-03 15:41:12,219 __retry_internal: WARN1NG: ...
```
We don't want to catch those with the filter - that's the whole point of mangling them.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
Warnings with just the text "warn" will not be caught, and mangled "warn1ing" will also not be caught.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux
```
ska3-jeanconn-kady> pytest
======================================================= test session starts ========================================================
platform linux -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 9 items                                                                                                                  

jobwatch/tests/test_jobwatch.py .........                                                                                    [100%]

======================================================== 9 passed in 15.55s ========================================================
ska3-jeanconn-kady> git rev-parse HEAD
1c62a38593182b3c5b050572cd388d69075755ad
```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->

Output https://icxc.cfa.harvard.edu/aspect/test_review_outputs/jobwatch/pr79/2025338/ is as-expected.
